### PR TITLE
move resource url from top level 'href' to 'self' in links key

### DIFF
--- a/lib/simple_json_api/resource_serializer.rb
+++ b/lib/simple_json_api/resource_serializer.rb
@@ -40,10 +40,10 @@ module SimpleJsonApi
       _fields.each do |attribute, _attr_opts|
         hash[attribute] = send(attribute).to_s
       end
-      hash[:href] = href if self.class.method_defined? :href
     end
 
     def link_values(root)
+      root[:self] = self.href if self.class.method_defined? :href
       self.class._associations.each do |association|
         root[association.key] = link(association)
       end

--- a/test/integration/render_basic_test.rb
+++ b/test/integration/render_basic_test.rb
@@ -25,8 +25,8 @@ module SimpleJsonApi
           'name' => 'First Project',
           'description' => 'The first project',
           'position' => '',
-          'href' => 'http://example.com/projects/100',
           'links' => {
+            'self' => 'http://example.com/projects/100',
             'todolist' => '200',
             'tags' => %w(10)
           }
@@ -49,8 +49,8 @@ module SimpleJsonApi
             'name' => 'First Project',
             'description' => 'The first project',
             'position' => '',
-            'href' => 'http://example.com/projects/100',
             'links' => {
+              'self' => 'http://example.com/projects/100',
               'todolist' => '200',
               'tags' => %w(10)
             }
@@ -61,8 +61,8 @@ module SimpleJsonApi
             'name' => 'Second Project',
             'description' => 'The second project',
             'position' => '',
-            'href' => 'http://example.com/projects/110',
             'links' => {
+              'self' => 'http://example.com/projects/110',
               'todolist' => '210',
               'tags' => %w(20)
             }

--- a/test/integration/render_fields_test.rb
+++ b/test/integration/render_fields_test.rb
@@ -29,8 +29,8 @@ module SimpleJsonApi
           'id' => '100',
           'name' => 'First Project',
           'description' => 'The first project',
-          'href' => 'http://example.com/projects/100',
           'links' => {
+            'self' => 'http://example.com/projects/100',
             'todolist' => '200',
             'tags' => ['10']
           }
@@ -53,8 +53,8 @@ module SimpleJsonApi
             'id' => '100',
             'name' => 'First Project',
             'description' => 'The first project',
-            'href' => 'http://example.com/projects/100',
             'links' => {
+              'self' => 'http://example.com/projects/100',
               'todolist' => '200',
               'tags' => ['10']
             }
@@ -64,8 +64,8 @@ module SimpleJsonApi
             'id' => '110',
             'name' => 'Second Project',
             'description' => 'The second project',
-            'href' => 'http://example.com/projects/110',
             'links' => {
+              'self' => 'http://example.com/projects/110',
               'todolist' => '210',
               'tags' => ['20']
             }
@@ -86,8 +86,8 @@ module SimpleJsonApi
           'type' => 'todos',
           'id' => '300',
           'action' => 'Milk',
-          'href' => 'http://example.com/todos/300',
           'links' => {
+            'self' => 'http://example.com/todos/300',
             'tags' => %w(10 30)
           }
         }

--- a/test/integration/render_include_test.rb
+++ b/test/integration/render_include_test.rb
@@ -26,8 +26,8 @@ module SimpleJsonApi
           'name' => 'First Project',
           'description' => 'The first project',
           'position' => '',
-          'href' => 'http://example.com/projects/100',
           'links' => {
+            'self' => 'http://example.com/projects/100',
             'todolist' => '200',
             'tags' => ['10']
           }
@@ -37,8 +37,8 @@ module SimpleJsonApi
             'type' => 'todolists',
             'id' => '200',
             'description' => 'Groceries',
-            'href' => 'http://example.com/todolists/200',
             'links' => {
+              'self' => 'http://example.com/todolists/200',
               'todos' => %w(300 301),
               'tags' => ['30']
             }
@@ -63,8 +63,8 @@ module SimpleJsonApi
             'name' => 'First Project',
             'description' => 'The first project',
             'position' => '',
-            'href' => 'http://example.com/projects/100',
             'links' => {
+              'self' => 'http://example.com/projects/100',
               'todolist' => '200',
               'tags' => ['10']
             }
@@ -75,8 +75,8 @@ module SimpleJsonApi
             'name' => 'Second Project',
             'description' => 'The second project',
             'position' => '',
-            'href' => 'http://example.com/projects/110',
             'links' => {
+              'self' => 'http://example.com/projects/110',
               'todolist' => '210',
               'tags' => ['20']
             }
@@ -87,8 +87,8 @@ module SimpleJsonApi
             'type' => 'todolists',
             'id' => '200',
             'description' => 'Groceries',
-            'href' => 'http://example.com/todolists/200',
             'links' => {
+              'self' => 'http://example.com/todolists/200',
               'todos' => %w(300 301),
               'tags' => ['30']
             }
@@ -98,8 +98,8 @@ module SimpleJsonApi
             'id' => '210',
             'description' => 'Groceries',
             'description' => 'Work',
-            'href' => 'http://example.com/todolists/210',
             'links' => {
+              'self' => 'http://example.com/todolists/210',
               'todos' => %w(310 320 330),
               'tags' => []
             }

--- a/test/integration/render_nested_include_test.rb
+++ b/test/integration/render_nested_include_test.rb
@@ -24,8 +24,8 @@ module SimpleJsonApi
         'data' => {
           'type' => 'projects',
           'id' => '100',
-          'href' => 'http://example.com/projects/100',
           'links' => {
+            'self' => 'http://example.com/projects/100',
             'todolist' => '200',
             'tags' => ['10']
           }
@@ -34,8 +34,8 @@ module SimpleJsonApi
           {
             'type' => 'todolists',
             'id' => '200',
-            'href' => 'http://example.com/todolists/200',
             'links' => {
+              'self' => 'http://example.com/todolists/200',
               'todos' => %w(300 301),
               'tags' => ['30']
             }
@@ -43,24 +43,24 @@ module SimpleJsonApi
           {
             'type' => 'todos',
             'id' => '300',
-            'href' => 'http://example.com/todos/300',
             'links' => {
+              'self' => 'http://example.com/todos/300',
               'tags' => %w(10 30)
             }
           },
           {
             'type' => 'todos',
             'id' => '301',
-            'href' => 'http://example.com/todos/301',
             'links' => {
+              'self' => 'http://example.com/todos/301',
               'tags' => %w(10)
             }
           },
           {
             'type' => 'todos',
             'id' => '330',
-            'href' => 'http://example.com/todos/330',
             'links' => {
+              'self' => 'http://example.com/todos/330',
               'tags' => %w(10)
             }
           }

--- a/test/integration/render_pagination_test.rb
+++ b/test/integration/render_pagination_test.rb
@@ -26,8 +26,8 @@ module SimpleJsonApi
           'name' => 'First Project',
           'description' => 'The first project',
           'position' => '',
-          'href' => 'http://example.com/projects/100',
           'links' => {
+            'self' => 'http://example.com/projects/100',
             'todolist' => '200',
             'tags' => %w(10)
           }
@@ -58,8 +58,8 @@ module SimpleJsonApi
             'name' => 'First Project',
             'description' => 'The first project',
             'position' => '',
-            'href' => 'http://example.com/projects/100',
             'links' => {
+              'self' => 'http://example.com/projects/100',
               'todolist' => '200',
               'tags' => %w(10)
             }
@@ -70,8 +70,8 @@ module SimpleJsonApi
             'name' => 'Second Project',
             'description' => 'The second project',
             'position' => '',
-            'href' => 'http://example.com/projects/110',
             'links' => {
+              'self' => 'http://example.com/projects/110',
               'todolist' => '210',
               'tags' => %w(20)
             }


### PR DESCRIPTION
Moving 'href' from a top level attribute to the 'self' key inside 'links' is a first step towards getting the links key up to date with JSON API RC3.